### PR TITLE
Override always default Android hostname verifier

### DIFF
--- a/https.android.ts
+++ b/https.android.ts
@@ -136,23 +136,22 @@ function getClient(reload: boolean = false): okhttp3.OkHttpClient {
 				}
 			}
 
-			if (peer.validatesDomainName == true) {
-				try {
-					client.hostnameVerifier(new javax.net.ssl.HostnameVerifier({
-						verify: function(hostname: string, session: javax.net.ssl.ISSLSession): boolean {
-							let pp = session.getPeerPrincipal().getName()
-							let hv = javax.net.ssl.HttpsURLConnection.getDefaultHostnameVerifier()
-							return (
-								hv.verify(peer.host, session) &&
-								peer.host == hostname &&
-								peer.host == session.getPeerHost() &&
-								pp.indexOf(peer.host) != -1
-							)
-						},
-					}))
-				} catch (error) {
-					console.error('nativescript-https > client.validatesDomainName error', error)
-				}
+			try {
+				client.hostnameVerifier(new javax.net.ssl.HostnameVerifier({
+					verify: function(hostname: string, session: javax.net.ssl.ISSLSession): boolean {
+						let pp = session.getPeerPrincipal().getName()
+						let hv = javax.net.ssl.HttpsURLConnection.getDefaultHostnameVerifier()
+						return (
+							!peer.validatesDomainName ||
+							hv.verify(peer.host, session) &&
+							peer.host == hostname &&
+							peer.host == session.getPeerHost() &&
+							pp.indexOf(peer.host) != -1
+						)
+					},
+				}))
+			} catch (error) {
+				console.error('nativescript-https > client.validatesDomainName error', error)
 			}
 
 		} else {


### PR DESCRIPTION
This fixes the following problem:
```
javax.net.ssl.SSLPeerUnverifiedException: Hostname WWW.XXX.YYY.ZZZ not verified:
... ...
subjectAltNames: [] ; Zone: <root> ; Task: Promise.then ; Value: javax.net.ssl.SSLPeerUnverifiedException: Hostname WWW.XXX.YYY.ZZZ not verified:
```
A couple of months ago, Android stopped accepting self-signed certificates without SAN value when performing a WS call. I took a look at nativescript-https's code and there's this option `validatesDomainName`: if `false`, it uses default Android hostname verification which throws the mentioned error; if `true`, it uses a custom hostname verifier.

With my proposed change, the custom verifier will always be used, but it will return `true` if `validatesDomainName === false` and will use current logic if `validatesDomainName === true`. This can be returned some lines before, just at the beginning of `verify` and save some processing, but I think it looks fancier this way. I'll modify the code if needed.

I used this for a development environment and I thought it was useful since I saw some people having the same problem. I think this could be useful for someone else.

Best regards from `_travelDevs`.