### PR TITLE
Allow for variable timeout

### DIFF
--- a/src/https.android.ts
+++ b/src/https.android.ts
@@ -186,6 +186,15 @@ export function request(opts: Https.HttpsRequestOptions): Promise<Https.HttpsRes
       if (opts.allowLargeResponse) {
         android.os.StrictMode.setThreadPolicy(android.os.StrictMode.ThreadPolicy.LAX);
       }
+	  
+	  //set connection timeout to override okhttp3 default
+      if (opts.timeout) {
+                client = client.newBuilder()
+                .connectTimeout(opts.timeout, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .writeTimeout(opts.timeout, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .readTimeout(opts.timeout, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .build();
+            }
 
       client.newCall(request.build()).enqueue(new okhttp3.Callback({
         onResponse: (task, response) => {

--- a/src/https.common.ts
+++ b/src/https.common.ts
@@ -23,6 +23,7 @@ export interface HttpsRequestOptions {
    * Note that once set to true, this policy remains active until the app is killed.
    */
   allowLargeResponse?: boolean;
+  timeout?: number;
 }
 
 export interface HttpsResponse {

--- a/src/https.ios.ts
+++ b/src/https.ios.ts
@@ -166,6 +166,10 @@ export function request(opts: Https.HttpsRequestOptions): Promise<Https.HttpsRes
           Object.keys(cont).forEach(key => dict.setValueForKey(cont[key] as any, key));
         }
       }
+	  
+	  if (opts.timeout) {
+          manager.requestSerializer.timeoutInterval = opts.timeout / 1000;
+      }
 
       let methods = {
         'GET': 'GETParametersSuccessFailure',


### PR DESCRIPTION
This simply allows for a configurable timeout to be applied instead of using the default 10 seconds