### PR TITLE
Added support for Array object types in iOS

### DIFF
--- a/src/https.ios.ts
+++ b/src/https.ios.ts
@@ -157,10 +157,16 @@ export function request(opts: Https.HttpsRequestOptions): Promise<Https.HttpsRes
         Object.keys(heads).forEach(key => manager.requestSerializer.setValueForHTTPHeaderField(heads[key] as any, key));
       }
 
-      let dict: NSMutableDictionary<string, any> = null;
+      let dict = null;
       if (opts.body) {
         let cont = opts.body;
-        if (isObject(cont)) {
+		 if (Array.isArray(cont)) {
+			dict = NSMutableArray.new();
+			cont.forEach(function (item, idx) {
+				dict.addObject(item);
+			});
+        }
+        else if (isObject(cont)) {
           dict = NSMutableDictionary.new<string, any>();
           Object.keys(cont).forEach(key => dict.setValueForKey(cont[key] as any, key));
         }


### PR DESCRIPTION
Allow for objects of array types to be included in the content of iOS http requests