### PR TITLE
allow wildcard domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,13 @@ export interface HttpsSSLPinningOptions {
 	certificate: string
 	allowInvalidCertificates?: boolean
 	validatesDomainName?: boolean
+	commonName?: string
 }
 ```
 Option | Description
 ------------ | -------------
-`host: string` | This must be the top level domain name eg `httpbin.org`.
+`host: string` | This must be the request domain name eg `sales.company.org`.
+`commonName?: string` | Default: options.host, set if certificate CN is different from the host eg `*.company.org`
 `certificate: string` | The uri path to your `.cer` certificate file.
 `allowInvalidCertificates?: boolean` | Default: `false`. This should **always** be `false` if you are using SSL pinning. Set this to `true` if you're using a self-signed certificate.
 `validatesDomainName?: boolean` | Default: `true`. Determines if the domain name should be validated with your pinned certificate.

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -47,7 +47,7 @@ export function getHttpbin() {
 }
 
 export function getHttpbinLargeResponse() {
-  getRequest('https://httpbin.org/bytes/100000', true);
+  getRequest('https://httpbin.org/bytes/100000', true); 
 }
 
 export function getMockbin() {
@@ -57,7 +57,7 @@ export function getMockbin() {
 export function enableSSLPinning(args: Observable.EventData) {
   let dir = fs.knownFolders.currentApp().getFolder('assets');
   let certificate = dir.getFile('httpbin.org.cer').path;
-  Https.enableSSLPinning({host: 'httpbin.org', certificate});
+  Https.enableSSLPinning({host: 'httpbin.org', commonName: "httpbin.org", certificate});
   console.log('enabled');
 }
 

--- a/src/https.android.ts
+++ b/src/https.android.ts
@@ -43,8 +43,8 @@ export function enableSSLPinning(options: Https.HttpsSSLPinningOptions) {
     }
     peer.host = options.host;
     peer.commonName = options.host;
-    if( options.commonName != null ){
-      peer.commonName = options.commonName
+    if ( options.commonName != null ) {
+      peer.commonName = options.commonName;
     }
     peer.certificate = certificate;
     if (options.allowInvalidCertificates === true) {
@@ -135,7 +135,7 @@ function getClient(reload: boolean = false, timeout: number = 10): okhttp3.OkHtt
                   hv.verify(peer.host, session) &&
                   peer.host === hostname &&
                   peer.host === session.getPeerHost() &&
-                  pp.indexOf(peer.commonName) != -1 
+                  pp.indexOf(peer.commonName) !== -1
               );
             },
           }));
@@ -228,10 +228,10 @@ export function request(opts: Https.HttpsRequestOptions): Promise<Https.HttpsRes
           // }
 
           let content = response.body().string();
-          try {
-            content = JSON.parse(content);
-          } catch (e) {
-          }
+            try {
+              content = JSON.parse(content);
+            } catch (e) {
+            }
 
           let statusCode = response.code();
 

--- a/src/https.android.ts
+++ b/src/https.android.ts
@@ -6,6 +6,7 @@ interface Ipeer {
   allowInvalidCertificates: boolean;
   validatesDomainName: boolean;
   host?: string;
+  commonName?: string;
   certificate?: string;
   x509Certificate?: java.security.cert.Certificate;
 }
@@ -41,6 +42,10 @@ export function enableSSLPinning(options: Https.HttpsSSLPinningOptions) {
       return;
     }
     peer.host = options.host;
+    peer.commonName = options.host;
+    if( options.commonName != null ){
+      peer.commonName = options.commonName
+    }
     peer.certificate = certificate;
     if (options.allowInvalidCertificates === true) {
       peer.allowInvalidCertificates = true;
@@ -130,7 +135,7 @@ function getClient(reload: boolean = false, timeout: number = 10): okhttp3.OkHtt
                   hv.verify(peer.host, session) &&
                   peer.host === hostname &&
                   peer.host === session.getPeerHost() &&
-                  pp.indexOf(peer.host) !== -1
+                  pp.indexOf(peer.commonName) != -1 
               );
             },
           }));
@@ -180,7 +185,7 @@ export function request(opts: Https.HttpsRequestOptions): Promise<Https.HttpsRes
       if ((['GET', 'HEAD'].indexOf(opts.method) !== -1) || (opts.method === 'DELETE' && !isDefined(opts.body))) {
         request[methods[opts.method]]();
       } else {
-        let type = <string>opts.headers['Content-Type'] || 'application/json';
+        let type = opts.headers && opts.headers['Content-Type'] ? <string>opts.headers['Content-Type'] : 'application/json';
         let body = <any>opts.body || {};
         try {
           body = JSON.stringify(body);

--- a/src/https.common.ts
+++ b/src/https.common.ts
@@ -5,6 +5,7 @@ export interface HttpsSSLPinningOptions {
   certificate: string;
   allowInvalidCertificates?: boolean;
   validatesDomainName?: boolean;
+  commonName?: string;
 }
 
 export interface HttpsRequestObject {


### PR DESCRIPTION
Add commonName option to handle cases where CN != hostName, eg host= sales.company.com, CN=*.company.com

See issue:

https://github.com/EddyVerbruggen/nativescript-https/issues/14