### PR TITLE
fix(ios): base URL for AFHTTPSessionManager

### DIFF
--- a/src/https/request.android.ts
+++ b/src/https/request.android.ts
@@ -22,6 +22,7 @@ const peer: Ipeer = {
 
 let cache: okhttp3.Cache;
 let forceCache = false;
+
 export function setCache(options?: CacheOptions) {
     if (options) {
         forceCache = options.forceCache === true;
@@ -34,6 +35,7 @@ export function setCache(options?: CacheOptions) {
         getClient(undefined, true);
     }
 }
+
 export function clearCache() {
     if (cache) {
         cache.evictAll();

--- a/src/https/request.common.ts
+++ b/src/https/request.common.ts
@@ -15,6 +15,7 @@ export function getFilenameFromUrl(url: string) {
 
     return result;
 }
+
 export function parseJSON(source: string): any {
     const src = source.trim();
     if (src.lastIndexOf(')') === src.length - 1) {
@@ -25,10 +26,13 @@ export function parseJSON(source: string): any {
 }
 
 export const interceptors = [];
+
 export function addInterceptor(interceptor) {
     interceptors.push(interceptor);
 }
+
 export const networkInterceptors = [];
+
 export function addNetworkInterceptor(interceptor) {
     networkInterceptors.push(interceptor);
 }

--- a/src/https/request.ios.ts
+++ b/src/https/request.ios.ts
@@ -13,6 +13,7 @@ export function setCache(options?: CacheOptions) {
     }
     NSURLCache.sharedURLCache = cache;
 }
+
 export function clearCache() {
     NSURLCache.sharedURLCache.removeAllCachedResponses();
 }
@@ -31,7 +32,12 @@ const policies: Ipolicies = {
 policies.def.allowInvalidCertificates = true;
 policies.def.validatesDomainName = false;
 
+const configuration = NSURLSessionConfiguration.defaultSessionConfiguration;
+let manager = AFHTTPSessionManager.alloc().initWithSessionConfiguration(configuration);
+
 export function enableSSLPinning(options: HttpsSSLPinningOptions) {
+    const url = NSURL.URLWithString(options.host);
+    manager = AFHTTPSessionManager.alloc().initWithSessionConfiguration(configuration).initWithBaseURL(url);
     if (!policies.secure) {
         policies.secure = AFSecurityPolicy.policyWithPinningMode(AFSSLPinningMode.PublicKey);
         policies.secure.allowInvalidCertificates = Utils.isDefined(options.allowInvalidCertificates) ? options.allowInvalidCertificates : false;
@@ -298,8 +304,6 @@ function bodyToNative(cont) {
     }
     return dict;
 }
-const configuration = NSURLSessionConfiguration.defaultSessionConfiguration;
-const manager = AFHTTPSessionManager.alloc().initWithSessionConfiguration(configuration);
 
 const runningRequests: { [k: string]: NSURLSessionDataTask } = {};
 
@@ -308,10 +312,11 @@ export function cancelRequest(tag: string) {
         runningRequests[tag].cancel();
     }
 }
+
 export function cancelAllRequests() {
-    Object.values(runningRequests).forEach(request=>{
-        request.cancel()
-    })
+    Object.values(runningRequests).forEach((request) => {
+        request.cancel();
+    });
 }
 
 export function clearCookies() {
@@ -373,8 +378,8 @@ export function createRequest(opts: HttpsRequestOptions, useLegacy: boolean = tr
 
     const progress = opts.onProgress
         ? (progress: NSProgress) => {
-            opts.onProgress(progress.completedUnitCount, progress.totalUnitCount);
-        }
+              opts.onProgress(progress.completedUnitCount, progress.totalUnitCount);
+          }
         : null;
     let task: NSURLSessionDataTask;
     const tag = opts.tag;
@@ -500,7 +505,8 @@ export function request(opts: HttpsRequestOptions, useLegacy: boolean = true) {
         }
     });
 }
-//Android only
+
+// Android only
 export function getClient(opts: Partial<HttpsRequestOptions>) {
     return undefined;
 }


### PR DESCRIPTION
Fix error for iOS:
```
ERROR Error: A security policy configured with `AFSSLPinningModeCertificate` can only be applied on a manager with a secure base URL (i.e. https)
```

So, now `AFHTTPSessionManager` reinitializes at `enableSSLPinning` with `HttpsSSLPinningOptions.host` base URL.