### PR TITLE
feat: Added support for removing cached responses using url

### DIFF
--- a/packages/https/platforms/android/java/com/nativescript/https/CacheUtils.java
+++ b/packages/https/platforms/android/java/com/nativescript/https/CacheUtils.java
@@ -1,17 +1,25 @@
 package com.nativescript.https;
 
+import java.util.Iterator;
 import okhttp3.Cache;
 
 public class CacheUtils {
     public static void removeCachedResponse(String url, Cache cache) {
-        final Iterator<String> it = cache.urls();
+        Iterator<String> it;
+        try {
+          it = cache.urls();
+        } catch (Exception e) {
+          it = null;
+        }
 
-        while (it.hasNext()) {
-            String cacheUrl = it.next();
-            
-            if (cacheUrl.equals(url)) {
-                it.remove();
-                break;
+        if (it != null) {
+            while (it.hasNext()) {
+                String cacheUrl = it.next();
+
+                if (cacheUrl.equals(url)) {
+                    it.remove();
+                    break;
+                }
             }
         }
     }

--- a/packages/https/platforms/android/java/com/nativescript/https/CacheUtils.java
+++ b/packages/https/platforms/android/java/com/nativescript/https/CacheUtils.java
@@ -1,0 +1,18 @@
+package com.nativescript.https;
+
+import okhttp3.Cache;
+
+public class CacheUtils {
+    public static void removeCachedResponse(String url, Cache cache) {
+        final Iterator<String> it = cache.urls();
+
+        while (it.hasNext()) {
+            String cacheUrl = it.next();
+            
+            if (cacheUrl.equals(url)) {
+                it.remove();
+                break;
+            }
+        }
+    }
+}

--- a/packages/https/platforms/android/native-api-usage.json
+++ b/packages/https/platforms/android/native-api-usage.json
@@ -30,6 +30,7 @@
         "java.net:CookiePolicy",
         "com.nativescript.https:QuotePreservingCookieJar",
         "com.nativescript.https:CacheInterceptor",
+        "com.nativescript.https:CacheUtils",
         "com.nativescript.https:OkHttpResponse",
         "java.util:Collections",
         "java.security.cert:CertificateFactory",

--- a/src/https/request.android.ts
+++ b/src/https/request.android.ts
@@ -52,18 +52,8 @@ export function clearCache() {
 }
 
 export function removeCachedResponse(url: string) {
-    if (!cache) {
-        return;
-    }
-
-    const iterator = cache.urls();
-
-    while (iterator.hasNext()) {
-        const cacheUrl = iterator.next();
-        if (cacheUrl === url) {
-            iterator.remove();
-            break;
-        }
+    if (cache) {
+        com.nativescript.https.CacheUtils.removeCachedResponse(url, cache);
     }
 }
 

--- a/src/https/request.android.ts
+++ b/src/https/request.android.ts
@@ -51,6 +51,22 @@ export function clearCache() {
     }
 }
 
+export function removeCachedResponse(url: string) {
+    if (!cache) {
+        return;
+    }
+
+    const iterator = cache.urls();
+
+    while (iterator.hasNext()) {
+        const cacheUrl = iterator.next();
+        if (cacheUrl === url) {
+            iterator.remove();
+            break;
+        }
+    }
+}
+
 // TODO: rewrite this to not have to handle
 // every single property
 let _timeout = 10;

--- a/src/https/request.d.ts
+++ b/src/https/request.d.ts
@@ -111,6 +111,7 @@ export declare function request<T = any, U extends boolean = true>(
 ): U extends true ? Promise<HttpsResponse<HttpsResponseLegacy<T>>> : Promise<HttpsResponse<T>>;
 export function setCache(options?: CacheOptions);
 export function clearCache();
+export function removeCachedResponse(url: string);
 export function createRequest(opts: HttpsRequestOptions): HttpsRequest;
 export function cancelRequest(tag: string);
 export function cancelAllRequests();

--- a/src/https/typings/android.d.ts
+++ b/src/https/typings/android.d.ts
@@ -7,6 +7,9 @@ declare namespace com {
             export class CacheInterceptor {
                 public static INTERCEPTOR: okhttp3.Interceptor;
             }
+            export class CacheUtils {
+                static removeCachedResponse(url: string, cache: okhttp3.Cache): void;
+            }
             export class OkHttpResponse {
                 progressCallback: OkHttpResponse.OkHttpResponseProgressCallback;
                 closeCallback: OkHttpResponse.OkHttpResponseCloseCallback;


### PR DESCRIPTION
This PR adds support for removing individual items from cache using the request URL as a key.

The feature is based on recommended native solutions per platform.
Android: https://square.github.io/okhttp/features/caching/#pruning-the-cache
iOS: https://developer.apple.com/documentation/foundation/nsurlcache/1415377-removecachedresponseforrequest

Note: iOS does not give access to cached items, therefore we create a new NSRequest with the url of the cached resource we want to remove. This solution is suggested by online examples and seems to work.