### PR TITLE
fix(ios): Unexpected end of JSON input

### DIFF
--- a/src/https/request.ios.ts
+++ b/src/https/request.ios.ts
@@ -177,7 +177,7 @@ class HttpsResponseLegacy implements IHttpsResponseLegacy {
             return data;
         }
         this.stringResponse = data;
-        this.jsonResponse = parseJSON(data);
+        this.jsonResponse = this.stringResponse ? parseJSON(data) : null;
         return this.jsonResponse as T;
     }
     toJSONAsync<T>() {

--- a/src/https/request.ios.ts
+++ b/src/https/request.ios.ts
@@ -177,7 +177,7 @@ class HttpsResponseLegacy implements IHttpsResponseLegacy {
             return data;
         }
         this.stringResponse = data;
-        this.jsonResponse = this.stringResponse ? parseJSON(data) : null;
+        this.jsonResponse = data ? parseJSON(data) : null;
         return this.jsonResponse as T;
     }
     toJSONAsync<T>() {


### PR DESCRIPTION
It seems that calling `toJSON` for response content on iOS will attempt to parse text even if it's a falsy value, resulting in SyntaxError.
This is already handled on android.