### PR TITLE
chore: Corrected HttpsRequestOptions method type

### DIFF
--- a/src/https/request.d.ts
+++ b/src/https/request.d.ts
@@ -34,7 +34,7 @@ export type CachePolicy = 'noCache' | 'onlyCache' | 'ignoreCache';
 export interface HttpsRequestOptions extends HttpRequestOptions {
     url: string;
     tag?: string; // optional request tag to allow to cancel it
-    method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD';
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
     headers?: Headers;
     params?: HttpsRequestObject;
     body?: HttpsRequestObject | HttpsFormDataParam[] | File;


### PR DESCRIPTION
This PR adds missing method `OPTIONS` to plugin types.